### PR TITLE
Build and publish legacy APK in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
         run: chmod +x gradlew scripts/*.sh
 
       - name: Build release artifacts
-        run: ./scripts/build-release-artifacts.sh "${{ steps.version.outputs.version }}" --skip-legacy
+        run: ./scripts/build-release-artifacts.sh "${{ steps.version.outputs.version }}"
 
       - name: Generate AI release notes
         env:


### PR DESCRIPTION
## Summary
- Drop `--skip-legacy` from `release.yml` so the release workflow builds the legacy Android APK alongside the main artifacts.
- `scripts/build-release-artifacts.sh` already applies `legacy-migration.patch`, runs `:android:assembleFossRelease`, and stages `android-legacy-foss-<version>.apk` in `release-<version>/`.
- Verified `legacy-migration.patch` still applies cleanly against current `develop` (`git apply --check` passes).

## Test plan
- [ ] Trigger `release.yml` (or push a `vA.B.C` tag) and confirm `android-legacy-foss-<version>.apk` is attached to the resulting GitHub Release.
- [ ] Install the legacy APK on an API 16/17 device and verify it launches.