### PR TITLE
Pause web audio on tab switch; stop rain when sound disabled

### DIFF
--- a/core/common/src/main/kotlin/ru/fredboy/cavedroid/common/api/SoundPlayer.kt
+++ b/core/common/src/main/kotlin/ru/fredboy/cavedroid/common/api/SoundPlayer.kt
@@ -15,4 +15,10 @@ interface SoundPlayer {
     fun playUiSound(sound: Sound)
 
     fun playLoopSound(sound: Sound, volume: Float): Long
+
+    fun stopLoopSound(sound: Sound, id: Long)
+
+    fun pauseAll()
+
+    fun resumeAll()
 }

--- a/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/CaveDroidApplication.kt
+++ b/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/CaveDroidApplication.kt
@@ -52,6 +52,9 @@ class CaveDroidApplication(
     override lateinit var applicationComponent: ApplicationComponent
         private set
 
+    val applicationComponentOrNull: ApplicationComponent?
+        get() = if (::applicationComponent.isInitialized) applicationComponent else null
+
     private fun initFullscreenMode(isFullscreen: Boolean) {
         if (Gdx.app.type != Application.ApplicationType.Desktop) {
             return

--- a/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/CaveDroidSoundPlayer.kt
+++ b/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/CaveDroidSoundPlayer.kt
@@ -13,6 +13,11 @@ class CaveDroidSoundPlayer @Inject constructor(
     private val applicationContextRepository: ApplicationContextRepository,
 ) : SoundPlayer {
 
+    // Track active loops so pauseAll/resumeAll only touch sounds we started — Web Audio
+    // forbids resume() before a user gesture if nothing was previously playing.
+    private val activeLoops = mutableMapOf<Sound, MutableSet<Long>>()
+    private var pausedLoops: Map<Sound, Set<Long>> = emptyMap()
+
     override fun playSoundAtPosition(
         sound: Sound,
         soundX: Float,
@@ -53,7 +58,35 @@ class CaveDroidSoundPlayer @Inject constructor(
             return -1L
         }
 
-        return sound.loop(volume)
+        val id = sound.loop(volume)
+        activeLoops.getOrPut(sound) { mutableSetOf() } += id
+        return id
+    }
+
+    override fun stopLoopSound(sound: Sound, id: Long) {
+        if (id == -1L) return
+        sound.stop(id)
+        activeLoops[sound]?.let { ids ->
+            ids -= id
+            if (ids.isEmpty()) {
+                activeLoops -= sound
+            }
+        }
+    }
+
+    override fun pauseAll() {
+        val snapshot = activeLoops.mapValues { it.value.toSet() }
+        pausedLoops = snapshot
+        snapshot.forEach { (sound, ids) ->
+            ids.forEach { sound.pause(it) }
+        }
+    }
+
+    override fun resumeAll() {
+        pausedLoops.forEach { (sound, ids) ->
+            ids.forEach { sound.resume(it) }
+        }
+        pausedLoops = emptyMap()
     }
 
     companion object {

--- a/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/game/WeatherSoundController.kt
+++ b/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/game/WeatherSoundController.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.utils.Disposable
 import ru.fredboy.cavedroid.common.api.SoundPlayer
 import ru.fredboy.cavedroid.common.di.GameScope
 import ru.fredboy.cavedroid.domain.assets.repository.WeatherSoundAssetsRepository
+import ru.fredboy.cavedroid.domain.configuration.repository.ApplicationContextRepository
 import ru.fredboy.cavedroid.domain.world.model.Biome
 import ru.fredboy.cavedroid.game.controller.mob.MobController
 import ru.fredboy.cavedroid.game.world.GameWorld
@@ -16,12 +17,18 @@ class WeatherSoundController @Inject constructor(
     private val mobController: MobController,
     private val weatherSoundAssetsRepository: WeatherSoundAssetsRepository,
     private val soundPlayer: SoundPlayer,
+    private val applicationContextRepository: ApplicationContextRepository,
 ) : Disposable {
 
     private var rainSound: Sound? = null
     private var rainSoundId: Long = -1L
 
     fun update() {
+        if (!applicationContextRepository.isSoundEnabled()) {
+            stopRain()
+            return
+        }
+
         val inRainBiome = gameWorld.getBiomeAt(mobController.player.mapX) == Biome.PLAINS
         val intensity = if (inRainBiome) gameWorld.weatherIntensity else 0f
 
@@ -43,7 +50,7 @@ class WeatherSoundController @Inject constructor(
     }
 
     private fun stopRain() {
-        rainSound?.takeIf { rainSoundId != -1L }?.stop(rainSoundId)
+        rainSound?.takeIf { rainSoundId != -1L }?.let { soundPlayer.stopLoopSound(it, rainSoundId) }
         rainSoundId = -1L
     }
 

--- a/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/menu/v2/view/newgame/NewGameMenuView.kt
+++ b/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/menu/v2/view/newgame/NewGameMenuView.kt
@@ -60,7 +60,6 @@ fun Stage.show(viewModel: NewGameMenuViewModel) {
                     }
                 }
 
-
                 row()
 
                 textButton(viewModel.getLocalizedString("creative")) {

--- a/html/src/main/kotlin/ru/fredboy/cavedroid/html/WebAudioLifecycle.kt
+++ b/html/src/main/kotlin/ru/fredboy/cavedroid/html/WebAudioLifecycle.kt
@@ -1,0 +1,35 @@
+package ru.fredboy.cavedroid.html
+
+import org.teavm.jso.JSBody
+
+internal object WebAudioLifecycle {
+
+    fun install(onSuspend: YaGamesCallback, onResume: YaGamesCallback) {
+        registerListeners(onSuspend, onResume)
+    }
+
+    // `visibilitychange` covers desktop tab switches and most Android browsers.
+    // `pagehide`/`pageshow` are the only reliable signals for iOS Safari swap-out
+    // and "page being closed" on mobile (where `unload` does not fire).
+    // `blur`/`focus` catch window minimize and out-of-tab focus loss.
+    @JvmStatic
+    @JSBody(
+        params = ["onSuspend", "onResume"],
+        script = """
+            try {
+                var suspend = function () { try { onSuspend(); } catch (e) { console.warn('[cavedroid] onSuspend failed:', e); } };
+                var resume = function () { try { onResume(); } catch (e) { console.warn('[cavedroid] onResume failed:', e); } };
+                document.addEventListener('visibilitychange', function () {
+                    if (document.visibilityState === 'hidden') { suspend(); } else { resume(); }
+                });
+                window.addEventListener('pagehide', suspend);
+                window.addEventListener('pageshow', resume);
+                window.addEventListener('blur', suspend);
+                window.addEventListener('focus', resume);
+            } catch (e) {
+                console.warn('[cavedroid] WebAudioLifecycle install failed:', e);
+            }
+        """,
+    )
+    external fun registerListeners(onSuspend: YaGamesCallback, onResume: YaGamesCallback)
+}

--- a/html/src/main/kotlin/ru/fredboy/cavedroid/html/WebLauncher.kt
+++ b/html/src/main/kotlin/ru/fredboy/cavedroid/html/WebLauncher.kt
@@ -33,10 +33,15 @@ object WebLauncher {
 
         val yandexAvailable = YandexGamesBridge.isAvailable()
         val adController: AdController = if (yandexAvailable) YandexGamesAdController() else NoOpAdController()
-        val onGameReady: (() -> Unit)? = if (yandexAvailable) {
-            { YandexGamesBridge.notifyLoadingReady() }
-        } else {
-            null
+
+        var appRef: CaveDroidApplication? = null
+        WebAudioLifecycle.install(
+            onSuspend = { appRef?.applicationComponentOrNull?.soundPlayer?.pauseAll() },
+            onResume = { appRef?.applicationComponentOrNull?.soundPlayer?.resumeAll() },
+        )
+
+        val onGameReady: () -> Unit = {
+            if (yandexAvailable) YandexGamesBridge.notifyLoadingReady()
         }
 
         val isMobileBrowser = isMobileBrowser()
@@ -63,6 +68,7 @@ object WebLauncher {
             onGameReady = onGameReady,
             loggingSeverity = Severity.Info,
         )
+        appRef = app
 
         WebApplication(app, config)
     }


### PR DESCRIPTION
## Summary

- Pause looping audio (currently rain) on the web target when the page is hidden, minimized, or about to be closed; resume on return. Required by Yandex Games review.
- Fix the rain loop continuing to play after the player toggles sound off mid-storm.

## Changes

- `WeatherSoundController` now bails out of `update()` when `isSoundEnabled()` is false, so toggling sound off stops the rain loop on the next tick instead of waiting for the rain to end.
- `SoundPlayer` gains `pauseAll()` / `resumeAll()` / `stopLoopSound()`. `CaveDroidSoundPlayer` tracks active loops so resume only touches loops it previously paused (Web Audio forbids `resume()` before a user gesture if nothing was playing).
- New `WebAudioLifecycle` registers `visibilitychange` / `pagehide` / `pageshow` / `blur` / `focus` listeners on the JS side. Covers iOS Safari (pagehide/pageshow), Android browsers, and desktop tab/minimize.
- `WebLauncher` installs the lifecycle bridge and routes its callbacks into `soundPlayer.pauseAll/resumeAll`, gated through `applicationComponentOrNull` so listeners that fire before libGDX `create()` are safe no-ops.

## Test plan

- [ ] `./gradlew html:runWeb`, enter a plains biome during rain, switch browser tab — rain audio stops; switch back — rain resumes.
- [ ] Same scenario, toggle sound off in settings during rain — rain stops immediately without waiting for the storm to end.
- [ ] `./gradlew desktop:run` to confirm desktop pause behavior is unchanged.
- [ ] `./gradlew :android:assembleFossDebug` and smoke-test rain audio on device — OS-driven pause path unchanged.
- [ ] `./gradlew ktlintCheck test` (already green locally).