### PR TITLE
Fix lit furnace not emitting light

### DIFF
--- a/assets/json/game_items.json
+++ b/assets/json/game_items.json
@@ -138,6 +138,9 @@
     },
     "crafting_table": {
       "hp": 180,
+      "collision": false,
+      "background": true,
+      "casts_shadows": false,
       "texture": "crafting_table",
       "tool_level": 0,
       "tool_type": "axe",
@@ -1830,8 +1833,10 @@
     },
     "furnace": {
       "hp": 1050,
-      "collision": true,
+      "collision": false,
+      "background": true,
       "transparent": false,
+      "casts_shadows": false,
       "drop": "furnace",
       "texture": "furnace",
       "animated": true,
@@ -1852,8 +1857,10 @@
     },
     "chest": {
       "hp": 180,
-      "collision": true,
+      "collision": false,
+      "background": true,
       "transparent": false,
+      "casts_shadows": false,
       "drop": "chest",
       "texture": "chest",
       "tool_level": 0,

--- a/core/common/src/main/kotlin/ru/fredboy/cavedroid/common/utils/GenericUtils.kt
+++ b/core/common/src/main/kotlin/ru/fredboy/cavedroid/common/utils/GenericUtils.kt
@@ -25,3 +25,5 @@ fun Boolean.takeIfTrue(): Boolean? = takeIf { it }
 fun String.startWithCapital(locale: Locale) = replaceFirstChar {
     if (it.isLowerCase()) it.titlecase(locale) else it.toString()
 }
+
+inline fun <reified T> Any?.safeCast(): T? = this as? T

--- a/core/data/save/src/main/kotlin/ru/fredboy/cavedroid/data/save/mapper/ContainerControllerMapper.kt
+++ b/core/data/save/src/main/kotlin/ru/fredboy/cavedroid/data/save/mapper/ContainerControllerMapper.kt
@@ -52,7 +52,9 @@ class ContainerControllerMapper @Inject constructor(
                 }
 
                 if (container != null) {
-                    containerMap.put(ContainerCoordinates.fromString(key), container)
+                    val coordinates = ContainerCoordinates.fromString(key)
+                    containerMap[coordinates] = container
+                    onContainerAdded(coordinates.x, coordinates.y, coordinates.z, container)
                 }
             }
         }

--- a/core/entity/container/src/main/kotlin/ru/fredboy/cavedroid/entity/container/model/Furnace.kt
+++ b/core/entity/container/src/main/kotlin/ru/fredboy/cavedroid/entity/container/model/Furnace.kt
@@ -1,6 +1,7 @@
 package ru.fredboy.cavedroid.entity.container.model
 
 import com.badlogic.gdx.math.MathUtils
+import com.badlogic.gdx.utils.Disposable
 import com.badlogic.gdx.utils.TimeUtils
 import ru.fredboy.cavedroid.domain.items.model.block.Block
 import ru.fredboy.cavedroid.domain.items.model.inventory.InventoryItem
@@ -16,7 +17,10 @@ class Furnace(
     size = SIZE,
     fallbackItem = fallbackItem,
     initialItems = initialItems,
-) {
+),
+    Disposable {
+
+    var notifyStateChanged: ((isActive: Boolean) -> Unit)? = null
 
     override val type get() = Block.Furnace::class
 
@@ -50,6 +54,7 @@ class Furnace(
             lightSource?.apply {
                 this@apply.isActive = value != null && !value.isNone()
             }
+            notifyStateChanged?.invoke(value != null && !value.isNone())
         }
 
     var currentFuelKey: String? = null
@@ -142,6 +147,11 @@ class Furnace(
             smeltStarTimeMs = TimeUtils.millis()
             smeltProgress = 0f
         }
+    }
+
+    override fun dispose() {
+        lightSource?.dispose()
+        notifyStateChanged = null
     }
 
     companion object {

--- a/core/game/controller/container/src/main/kotlin/ru/fredboy/cavedroid/game/controller/container/ContainerController.kt
+++ b/core/game/controller/container/src/main/kotlin/ru/fredboy/cavedroid/game/controller/container/ContainerController.kt
@@ -1,6 +1,8 @@
 package ru.fredboy.cavedroid.game.controller.container
 
+import com.badlogic.gdx.utils.Disposable
 import ru.fredboy.cavedroid.common.di.GameScope
+import ru.fredboy.cavedroid.common.utils.removeFirst
 import ru.fredboy.cavedroid.domain.items.model.block.Block
 import ru.fredboy.cavedroid.domain.items.usecase.GetItemByKeyUseCase
 import ru.fredboy.cavedroid.domain.world.lighting.LightHandle
@@ -13,6 +15,8 @@ import ru.fredboy.cavedroid.entity.container.model.Container
 import ru.fredboy.cavedroid.entity.container.model.ContainerCoordinates
 import ru.fredboy.cavedroid.entity.container.model.Furnace
 import ru.fredboy.cavedroid.entity.drop.abstraction.DropAdapter
+import java.lang.ref.WeakReference
+import java.util.LinkedList
 import javax.inject.Inject
 
 @GameScope
@@ -23,6 +27,8 @@ class ContainerController @Inject constructor(
     private val dropAdapter: DropAdapter,
 ) : OnBlockPlacedListener,
     OnBlockDestroyedListener {
+
+    private val furnaceStateChangedListeners = LinkedList<WeakReference<FurnaceStateChangedListener>>()
 
     val containerMap = mutableMapOf<ContainerCoordinates, Container>()
 
@@ -37,8 +43,36 @@ class ContainerController @Inject constructor(
         return ContainerCoordinates(x, y, z)
     }
 
+    fun addFurnaceListener(listener: FurnaceStateChangedListener) {
+        furnaceStateChangedListeners.add(WeakReference(listener))
+    }
+
+    fun removeFurnaceListener(listener: FurnaceStateChangedListener) {
+        furnaceStateChangedListeners.removeFirst { it.get() == listener }
+    }
+
+    private fun notifyFurnaceStateUpdated(x: Int, y: Int, z: Int, isActive: Boolean) {
+        furnaceStateChangedListeners.removeAll { listener ->
+            listener.get()?.let {
+                it.onFurnaceStateChanged(x, y, z, isActive)
+                return@removeAll false
+            }
+
+            logger.w { "An empty FurnaceStateChangedListener weak reference was removed!" }
+            true
+        }
+    }
+
     fun getContainer(x: Int, y: Int, z: Int): Container? {
         return containerMap[getContainerKey(x, y, z)]
+    }
+
+    fun onContainerAdded(x: Int, y: Int, z: Int, container: Container) {
+        if (container is Furnace) {
+            container.notifyStateChanged = { isActive ->
+                notifyFurnaceStateUpdated(x, y, z, isActive)
+            }
+        }
     }
 
     fun addContainer(x: Int, y: Int, z: Int, container: Container) {
@@ -48,6 +82,7 @@ class ContainerController @Inject constructor(
         }
 
         containerMap[key] = container
+        onContainerAdded(x, y, z, container)
     }
 
     private fun retrieveContainer(x: Int, y: Int, z: Int): Container? {
@@ -62,8 +97,8 @@ class ContainerController @Inject constructor(
         retrieveContainer(x, y, z)?.let { container ->
             dropAdapter.dropInventory(x.toFloat(), y.toFloat(), container.inventory)
 
-            if (container is Furnace) {
-                container.lightSource?.dispose()
+            if (container is Disposable) {
+                container.dispose()
             }
         }
     }
@@ -88,9 +123,14 @@ class ContainerController @Inject constructor(
     }
 
     fun dispose() {
+        containerMap.values.asSequence()
+            .filterIsInstance<Disposable>()
+            .forEach { container -> container.dispose() }
+
         containerMap.clear()
         containerWorldAdapter.removeOnBlockPlacedListener(this)
         containerWorldAdapter.removeOnBlockDestroyedListener(this)
+        furnaceStateChangedListeners.clear()
     }
 
     override fun onBlockDestroyed(

--- a/core/game/controller/container/src/main/kotlin/ru/fredboy/cavedroid/game/controller/container/FurnaceStateChangedListener.kt
+++ b/core/game/controller/container/src/main/kotlin/ru/fredboy/cavedroid/game/controller/container/FurnaceStateChangedListener.kt
@@ -1,0 +1,6 @@
+package ru.fredboy.cavedroid.game.controller.container
+
+fun interface FurnaceStateChangedListener {
+
+    fun onFurnaceStateChanged(x: Int, y: Int, z: Int, isActive: Boolean)
+}

--- a/core/gameplay/rendering/src/main/kotlin/ru/fredboy/cavedroid/gameplay/rendering/renderer/world/BackgroundBlocksRenderer.kt
+++ b/core/gameplay/rendering/src/main/kotlin/ru/fredboy/cavedroid/gameplay/rendering/renderer/world/BackgroundBlocksRenderer.kt
@@ -48,7 +48,15 @@ class BackgroundBlocksRenderer @Inject constructor(
             spriteBatch = spriteBatch,
             viewport = viewport,
             chunks = bgChunks,
-            chunkFactory = { x, y -> ChunkFrameBuffer(x, y, gameWorld, RenderingTool.SpriteBatch()) },
+            chunkFactory = { x, y ->
+                ChunkFrameBuffer(
+                    chunkX = x,
+                    chunkY = y,
+                    gameWorld = gameWorld,
+                    containerController = containerController,
+                    renderingTool = RenderingTool.SpriteBatch(),
+                )
+            },
             drawFunction = { batch, x, y, drawX, drawY -> drawBackMap(batch.spriteBatch, x, y, drawX, drawY) },
         )
 
@@ -66,6 +74,7 @@ class BackgroundBlocksRenderer @Inject constructor(
                     chunkX = x,
                     chunkY = y,
                     gameWorld = gameWorld,
+                    containerController = containerController,
                     renderingTool = RenderingTool.ShapeRenderer().apply {
                         this@apply.shapeRenderer.setColor(0f, 0f, 0f, .5f)
                     },
@@ -82,7 +91,15 @@ class BackgroundBlocksRenderer @Inject constructor(
             spriteBatch = spriteBatch,
             viewport = viewport,
             chunks = fgChunks,
-            chunkFactory = { x, y -> ChunkFrameBuffer(x, y, gameWorld, RenderingTool.SpriteBatch()) },
+            chunkFactory = { x, y ->
+                ChunkFrameBuffer(
+                    chunkX = x,
+                    chunkY = y,
+                    gameWorld = gameWorld,
+                    containerController = containerController,
+                    renderingTool = RenderingTool.SpriteBatch(),
+                )
+            },
             drawFunction = { batch, x, y, drawX, drawY -> drawForeMap(batch.spriteBatch, x, y, drawX, drawY) },
         )
     }

--- a/core/gameplay/rendering/src/main/kotlin/ru/fredboy/cavedroid/gameplay/rendering/renderer/world/BlocksRenderer.kt
+++ b/core/gameplay/rendering/src/main/kotlin/ru/fredboy/cavedroid/gameplay/rendering/renderer/world/BlocksRenderer.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.math.MathUtils
 import com.badlogic.gdx.math.Rectangle
 import ru.fredboy.cavedroid.common.model.SpriteOrigin
 import ru.fredboy.cavedroid.common.utils.drawSprite
+import ru.fredboy.cavedroid.common.utils.safeCast
 import ru.fredboy.cavedroid.domain.assets.usecase.GetBlockDamageFrameCountUseCase
 import ru.fredboy.cavedroid.domain.assets.usecase.GetBlockDamageSpriteUseCase
 import ru.fredboy.cavedroid.domain.items.model.block.Block
@@ -118,6 +119,10 @@ abstract class BlocksRenderer(
                 backgroundBlock.draw(spriteBatch, drawX, drawY)
             }
         }
+
+        containerController.getContainer(x, y, Layer.BACKGROUND.z)
+            ?.safeCast<Furnace>()
+            ?.let { furnace -> furnace.lightSource?.update() }
     }
 
     protected fun drawForeMap(spriteBatch: SpriteBatch, x: Int, y: Int, drawX: Float, drawY: Float) {
@@ -133,6 +138,10 @@ abstract class BlocksRenderer(
                 foregroundBlock.draw(spriteBatch, drawX, drawY)
             }
         }
+
+        containerController.getContainer(x, y, Layer.FOREGROUND.z)
+            ?.safeCast<Furnace>()
+            ?.let { furnace -> furnace.lightSource?.update() }
     }
 
     private fun drawAttachedToNeighbour(

--- a/core/gameplay/rendering/src/main/kotlin/ru/fredboy/cavedroid/gameplay/rendering/renderer/world/ForegroundBlocksRenderer.kt
+++ b/core/gameplay/rendering/src/main/kotlin/ru/fredboy/cavedroid/gameplay/rendering/renderer/world/ForegroundBlocksRenderer.kt
@@ -45,7 +45,15 @@ class ForegroundBlocksRenderer @Inject constructor(
             spriteBatch = spriteBatch,
             viewport = viewport,
             chunks = chunks,
-            chunkFactory = { x, y -> ChunkFrameBuffer(x, y, gameWorld, RenderingTool.SpriteBatch()) },
+            chunkFactory = { x, y ->
+                ChunkFrameBuffer(
+                    chunkX = x,
+                    chunkY = y,
+                    gameWorld = gameWorld,
+                    containerController = containerController,
+                    renderingTool = RenderingTool.SpriteBatch(),
+                )
+            },
             drawFunction = { batch, x, y, drawX, drawY -> drawForeMap(batch.spriteBatch, x, y, drawX, drawY) },
         )
 

--- a/core/gameplay/rendering/src/main/kotlin/ru/fredboy/cavedroid/gameplay/rendering/utils/ChunkFrameBuffer.kt
+++ b/core/gameplay/rendering/src/main/kotlin/ru/fredboy/cavedroid/gameplay/rendering/utils/ChunkFrameBuffer.kt
@@ -12,12 +12,15 @@ import com.badlogic.gdx.utils.Disposable
 import ru.fredboy.cavedroid.common.utils.PIXELS_PER_METER
 import ru.fredboy.cavedroid.common.utils.wrapsIntoRange
 import ru.fredboy.cavedroid.domain.world.listener.OnBlockPlacedListener
+import ru.fredboy.cavedroid.game.controller.container.ContainerController
+import ru.fredboy.cavedroid.game.controller.container.FurnaceStateChangedListener
 import ru.fredboy.cavedroid.game.world.GameWorld
 
 class ChunkFrameBuffer<Renderer : RenderingTool>(
     private val chunkX: Int,
     private val chunkY: Int,
     private val gameWorld: GameWorld,
+    private val containerController: ContainerController,
     private val renderingTool: Renderer,
 ) : Disposable {
 
@@ -49,10 +52,18 @@ class ChunkFrameBuffer<Renderer : RenderingTool>(
         }
     }
 
+    private val furnaceStateChangedListener = FurnaceStateChangedListener { x, y, _, _ ->
+        if (y < chunkWorldY || y >= chunkWorldY + CHUNK_SIZE) return@FurnaceStateChangedListener
+        if (wrapsIntoRange(x, chunkWorldX, CHUNK_SIZE, gameWorld.width)) {
+            dirty = true
+        }
+    }
+
     var dirty = true
 
     init {
         gameWorld.addBlockPlacedListener(onBlockPlacedListener)
+        containerController.addFurnaceListener(furnaceStateChangedListener)
     }
 
     fun rebuild(drawFunction: (Renderer, Int, Int, Float, Float) -> Unit) {
@@ -102,6 +113,7 @@ class ChunkFrameBuffer<Renderer : RenderingTool>(
         renderingTool.dispose()
         fbo.dispose()
         gameWorld.removeBlockPlacedListener(onBlockPlacedListener)
+        containerController.removeFurnaceListener(furnaceStateChangedListener)
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- Make furnace/chest/crafting_table non-collidable with `casts_shadows: false` so the furnace's own collider no longer blocks its emitted light.
- Add a `FurnaceStateChangedListener` so the chunk frame buffer invalidates its cached sprites when a furnace toggles between lit and unlit (fixes the lit texture not showing).
- Force `lightSource.update()` from the block renderer when a furnace tile is drawn — the box2dlights `PointLight` mesh is computed during construction with a null contact filter (filter is set in the post-construction `apply { }`), leaving the cached mesh stale. Refreshing it during the chunk rebuild piggybacks on the existing dirty cycle.

## Test plan
- [ ] Place a furnace in the dark; verify it does not emit light until fuel is added.
- [ ] Add fuel and a smeltable item; verify the lit texture appears and the surrounding area lights up.
- [ ] Burn through all fuel; verify the light fades and the texture reverts.
- [ ] Save and reload a world containing a lit furnace; verify it still emits light.
- [ ] Place blocks adjacent to a lit furnace; verify shadows update correctly.