### PR TITLE
Add dedicated save button to pause menu

### DIFF
--- a/assets/i18n/CaveDroid_Menu_de.properties
+++ b/assets/i18n/CaveDroid_Menu_de.properties
@@ -17,6 +17,7 @@ survival=Überleben
 copy=Kopieren
 pauseMenu=Pausenmenü
 resumeGame=Spiel fortsetzen
+saveGame=Spiel speichern
 quit=Verlassen
 dynamicCamera=Dynamische Kamera: {0}
 fullscreen=Vollbild: {0}

--- a/assets/i18n/CaveDroid_Menu_en.properties
+++ b/assets/i18n/CaveDroid_Menu_en.properties
@@ -17,6 +17,7 @@ survival=Survival
 copy=Copy
 pauseMenu=Pause Menu
 resumeGame=Resume Game
+saveGame=Save Game
 quit=Quit
 dynamicCamera=Dynamic Camera: {0}
 fullscreen=Fullscreen: {0}

--- a/assets/i18n/CaveDroid_Menu_ru.properties
+++ b/assets/i18n/CaveDroid_Menu_ru.properties
@@ -17,6 +17,7 @@ survival=Выживание
 copy=Копировать
 pauseMenu=Меню паузы
 resumeGame=Продолжить игру
+saveGame=Сохранить игру
 quit=Выйти
 dynamicCamera=Динамическая камера: {0}
 fullscreen=Полноэкранный режим: {0}

--- a/core/common/src/main/kotlin/ru/fredboy/cavedroid/common/api/ApplicationController.kt
+++ b/core/common/src/main/kotlin/ru/fredboy/cavedroid/common/api/ApplicationController.kt
@@ -17,6 +17,8 @@ interface ApplicationController : ApplicationListener {
 
     fun pauseGame()
 
+    fun saveGame()
+
     fun showDeathScreen()
 
     fun respawnPlayer()

--- a/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/CaveDroidApplication.kt
+++ b/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/CaveDroidApplication.kt
@@ -182,6 +182,18 @@ class CaveDroidApplication(
         screen.resume()
     }
 
+    override fun saveGame() {
+        val gameScreen = when (val currentScreen = screen) {
+            is GameScreen -> currentScreen
+            is PauseMenuScreen -> applicationComponent.gameScreen
+            else -> {
+                logger.w { "Cannot save when no game session is active" }
+                return
+            }
+        }
+        gameScreen.saveGame()
+    }
+
     override fun showDeathScreen() {
         if (screen !is GameScreen) {
             logger.w { "Cannot show death screen when active screen is not game" }

--- a/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/menu/v2/view/pause/PauseMenuView.kt
+++ b/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/menu/v2/view/pause/PauseMenuView.kt
@@ -36,6 +36,14 @@ fun Stage.pauseMenuView(viewModel: PauseMenuViewModel) = viewModel.also {
 
             row()
 
+            textButton(viewModel.getLocalizedString("saveGame")) {
+                onClickWithSound(viewModel) {
+                    viewModel.onSaveClick()
+                }
+            }
+
+            row()
+
             textButton(viewModel.getLocalizedString("settings")) {
                 onClickWithSound(viewModel) {
                     viewModel.onSettingsClick()

--- a/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/menu/v2/view/pause/PauseMenuViewModel.kt
+++ b/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/menu/v2/view/pause/PauseMenuViewModel.kt
@@ -16,6 +16,10 @@ class PauseMenuViewModel(
         applicationController.resumeGame()
     }
 
+    fun onSaveClick() {
+        applicationController.saveGame()
+    }
+
     fun onSettingsClick() {
         navBackStack.push(SettingsMenuNavKey)
     }


### PR DESCRIPTION
## Summary
- New `Save Game` button in the pause menu between Resume and Settings.
- Routes through a new `ApplicationController.saveGame()` that guards on the current screen (only saves when in `GameScreen` or `PauseMenuScreen`).
- Adds localized strings for en, ru, de.

## Test plan
- [ ] Start a game, pause, click Save — world persists.
- [ ] Verify Resume still works after saving.
- [ ] Verify Quit still saves on exit.