### PR TITLE
Show native language names in language menu

### DIFF
--- a/core/common/src/main/kotlin/ru/fredboy/cavedroid/common/utils/GenericUtils.kt
+++ b/core/common/src/main/kotlin/ru/fredboy/cavedroid/common/utils/GenericUtils.kt
@@ -26,4 +26,11 @@ fun String.startWithCapital(locale: Locale) = replaceFirstChar {
     if (it.isLowerCase()) it.titlecase(locale) else it.toString()
 }
 
+fun Locale.nativeDisplayName(): String = when (language) {
+    "en" -> "English"
+    "ru" -> "Русский"
+    "de" -> "Deutsch"
+    else -> getDisplayLanguage(this).startWithCapital(this)
+}
+
 inline fun <reified T> Any?.safeCast(): T? = this as? T

--- a/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/menu/v2/view/language/LanguageMenuView.kt
+++ b/core/gdx/src/main/kotlin/ru/fredboy/cavedroid/gdx/menu/v2/view/language/LanguageMenuView.kt
@@ -10,7 +10,7 @@ import ktx.scene2d.label
 import ktx.scene2d.scrollPane
 import ktx.scene2d.table
 import ktx.scene2d.textButton
-import ru.fredboy.cavedroid.common.utils.startWithCapital
+import ru.fredboy.cavedroid.common.utils.nativeDisplayName
 import ru.fredboy.cavedroid.gdx.menu.v2.view.common.onClickWithSound
 
 @Scene2dDsl
@@ -45,7 +45,7 @@ fun Stage.languageMenuView(viewModel: LanguageMenuViewModel) = viewModel.also {
                         .pad(10f)
 
                     viewModel.locales.map { locale ->
-                        textButton(locale.getDisplayLanguage(locale).startWithCapital(locale)) {
+                        textButton(locale.nativeDisplayName()) {
                             onClickWithSound(viewModel) {
                                 viewModel.onLanguageSelect(locale)
                             }


### PR DESCRIPTION
## Summary
- On the web build, the language list showed `English / Ru / De` because TeaVM's `Locale` doesn't ship CLDR display-name data, so `getDisplayLanguage(locale)` falls back to the language code.
- Added `Locale.nativeDisplayName()` with hardcoded native names for the three supported locales (`English`, `Русский`, `Deutsch`); JDK fallback remains for any future additions.
- Language menu now uses this helper, restoring the localized names on web (other platforms render identical strings to before).

## Test plan
- [ ] `./gradlew html:runWeb` → open the language menu, verify `English / Русский / Deutsch`.
- [ ] `./gradlew desktop:run` → language menu still shows the same native names.