### PR TITLE
Disable long-tap callout and pull-to-refresh on Yandex build

### DIFF
--- a/html/src/main/resources/webapp/index-yandex.html
+++ b/html/src/main/resources/webapp/index-yandex.html
@@ -11,6 +11,11 @@
                 margin: 0;
                 padding: 0;
                 overflow: hidden;
+                -webkit-user-select: none;
+                -webkit-touch-callout: none;
+                user-select: none;
+                touch-action: none;
+                overscroll-behavior: contain;
             }
             body {
                 display: flex;
@@ -19,6 +24,10 @@
             }
             #canvas {
                 border: none;
+                -webkit-user-select: none;
+                -webkit-touch-callout: none;
+                user-select: none;
+                touch-action: none;
             }
         </style>
         <script>


### PR DESCRIPTION
## Summary
- Add `-webkit-touch-callout: none`, `user-select: none`, `touch-action: none`, and `overscroll-behavior: contain` to `index-yandex.html` so the Yandex Games web build no longer triggers iOS long-press menus, text selection, pinch-zoom, or Android swipe-to-refresh.
- Addresses point 5 of the Yandex Games audit (requirements 1.6.1 and 1.10).

## Test plan
- [ ] Run `./gradlew html:runWeb` (Yandex variant) and verify long-press on the canvas doesn't show the iOS callout menu on a real iOS device.
- [ ] On Android Chrome, confirm swipe-down from the top doesn't trigger pull-to-refresh.
- [ ] Confirm desktop input and canvas rendering still work normally.